### PR TITLE
Systemd

### DIFF
--- a/GoodWe.py
+++ b/GoodWe.py
@@ -92,7 +92,8 @@ class GoodWeProcessor(object):
 
 class MyDaemon(Daemon):
     def run(self):
-        GoodWeProcessor.run_process()
+        processor = GoodWeProcessor()
+        processor.run_process()
 
     
 if __name__ == "__main__":
@@ -104,8 +105,9 @@ if __name__ == "__main__":
         processor = GoodWeProcessor()
         ret_val = processor.run_process()
         sys.exit(retval)
- 
+
     daemon = MyDaemon('/var/run/goodwecomm.pid', '/dev/null', '/dev/null', '/dev/null')
+ 
     if 'start' == sys.argv[1]:
         daemon.start()
     elif 'stop' == sys.argv[1]:

--- a/GoodWe.py
+++ b/GoodWe.py
@@ -102,7 +102,7 @@ class MyDaemon(Daemon):
     
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print ("usage: %s start|stop|restart" % sys.argv[0])
+        print ("usage: %s start|stop|restart|foreground" % sys.argv[0])
         sys.exit(2)
 
     if 'foreground' == sys.argv[1]:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Almost all configuration parameters have sensible defaults and are commented out
 setting remove the # in front of the parameter name.
 Only when username and the optional password are set, they will be used. Setting the username will trigger authentication for the MQTT server. 
 Password can optionally be set.
+Please note that the logfile is nt used when used in foreground mode.
 
 ## Usage
 
@@ -72,6 +73,11 @@ To start the daemon application:
 
 ```bash
 $ sudo ./GoodWe.py start
+```
+The program can also be started in the foreground with all logging to stderr (the logfile is not used). Strt the program as follows:
+
+```bash
+$ sudo ./Goodwe.py foreground
 ```
 
 ## Inverter information
@@ -100,3 +106,25 @@ goodwe "GoodWe.py" "cd /opt/goodweusblogger; ./GoodWe.py restart"
 ```
 
 I have everything running from _/opt/goodweusblogger_. If you have your application installed somewhere else you need to update the above statement.
+
+## Systemd
+
+Running under systemd is an option for using restartd. Systemd will collect all logging information in it's journal. The following goodwe.service file runs under the user "goodwe".
+Create the user as follows:
+
+```bash
+
+useradd --system goodwe
+
+```
+
+and modify the _/etc/udev/rules.d/98-my-usb-device.rules_ as follows:
+
+```bash
+
+SUBSYSTEM=="input", GROUP="input", MODE="0666"
+KERNEL=="hidraw*", ATTRS{busnum}=="1", ATTRS{idVendor}=="0084", ATTRS{idProduct}=="0041", MODE="0660", GROUP="goodwe"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0084", ATTRS{idProduct}=="0041", MODE="0660", GROUP="plugdev", SYMLINK+="goodwe"
+
+```
+

--- a/README.md
+++ b/README.md
@@ -42,18 +42,25 @@ Create file _/etc/goodwe.conf_:
 
 ```
 [inverter]
-loglevel = INFO
-pollinterval = 2500
-vendorId = 0084
-modelId = 0041
-logfile = /var/log/goodwe.log
+#loglevel = DEBUG
+#pollinterval = 2500
+#vendorId = 0084
+#modelId = 0041
+#logfile = /var/log/goodwe.log
 
 [mqtt]
-server = <MQTT Server IP>
-port = 1883
-topic = goodwe
-clientid = <unique MQTT client id>
+#server = localhost
+#port = 1883
+#topic = goodwe
+#clientid = goodwe-usb
+#username = 
+#password = mypassword
+
 ```
+Almost all configuration parameters have sensible defaults and are commented out. The values shown are the defaults. If you ned to change a 
+setting remove the # in front of the parameter name.
+Only when username and the optional password are set, they will be used. Setting the username will trigger authentication for the MQTT server. 
+Password can optionally be set.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Create file _/etc/goodwe.conf_:
 #password = mypassword
 
 ```
-Almost all configuration parameters have sensible defaults and are commented out. The values shown are the defaults. If you ned to change a 
+Almost all configuration parameters have sensible defaults and are commented out. The values shown are the defaults. If you need to change a 
 setting remove the # in front of the parameter name.
 Only when username and the optional password are set, they will be used. Setting the username will trigger authentication for the MQTT server. 
 Password can optionally be set.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Almost all configuration parameters have sensible defaults and are commented out
 setting remove the # in front of the parameter name.
 Only when username and the optional password are set, they will be used. Setting the username will trigger authentication for the MQTT server. 
 Password can optionally be set.
-Please note that the logfile is nt used when used in foreground mode.
+Please note that the logfile is not used when used in foreground mode.
 
 ## Usage
 
@@ -74,7 +74,7 @@ To start the daemon application:
 ```bash
 $ sudo ./GoodWe.py start
 ```
-The program can also be started in the foreground with all logging to stderr (the logfile is not used). Strt the program as follows:
+The program can also be started in the foreground with all logging to stderr (the logfile is not used). Start the program as follows:
 
 ```bash
 $ sudo ./Goodwe.py foreground
@@ -109,7 +109,9 @@ I have everything running from _/opt/goodweusblogger_. If you have your applicat
 
 ## Systemd
 
-Running under systemd is an option for using restartd. Systemd will collect all logging information in it's journal. The following goodwe.service file runs under the user "goodwe".
+Running under systemd is an option for using restartd. Systemd will collect all logging information in it's journal. 
+The service unit allows one to run as a system user.
+
 Create the user as follows:
 
 ```bash
@@ -127,4 +129,23 @@ KERNEL=="hidraw*", ATTRS{busnum}=="1", ATTRS{idVendor}=="0084", ATTRS{idProduct}
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0084", ATTRS{idProduct}=="0041", MODE="0660", GROUP="plugdev", SYMLINK+="goodwe"
 
 ```
+The following goodwe.service file shall be placed in _/etc/systemd/system/goodwe.service.
 
+```bash
+[Unit]
+Description=Goodwe USB Logger
+After=basic.target
+
+[Service]
+Type=simple
+User=goodwe
+Group=goodwe
+ExecStart=/opt/goodweusblogger/GoodWe.py foreground
+Restart=always
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+The program can now as usual be started by _systemctl start goodwe.service_

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ KERNEL=="hidraw*", ATTRS{busnum}=="1", ATTRS{idVendor}=="0084", ATTRS{idProduct}
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0084", ATTRS{idProduct}=="0041", MODE="0660", GROUP="plugdev", SYMLINK+="goodwe"
 
 ```
-The following goodwe.service file shall be placed in _/etc/systemd/system/goodwe.service.
+The following goodwe.service file shall be placed in _/etc/systemd/system/goodwe.service_.
 
 ```bash
 [Unit]
@@ -149,3 +149,4 @@ StandardError=journal
 WantedBy=multi-user.target
 ```
 The program can now as usual be started by _systemctl start goodwe.service_
+Systemd will run the program as the user goodwe and take care of restarting it when necessary. All logging information will be shown in the systemd logs.


### PR DESCRIPTION
hi Sircuri,
Here is one more pull request. This time for systemd support:
- added a start option (GoodWe.py foreground) that runs without forking and does all logging to stderr. This allows systemd tools to be used to collect and view the logs. No more need for a separate logfile. This also makes it easier to run under a different user than root
- Add a change for the udev rules that makes /dev/hidraw* accessable to the group goodwe
- The systemd unit will use user/group goodwe

One question: I noticed that Idinfo and settings info are not populated. I noticed that this is due to a commit earlier this year. Are you planning to bring them back or should they be removed?