### PR TITLE
Python3

### DIFF
--- a/GoodWe.py
+++ b/GoodWe.py
@@ -92,7 +92,8 @@ class GoodWeProcessor(object):
 
 class MyDaemon(Daemon):
     def run(self):
-        GoodWeProcessor.run_process()
+        processor = GoodWeProcessor()
+        processor.run_process()
 
     
 if __name__ == "__main__":
@@ -104,8 +105,9 @@ if __name__ == "__main__":
         processor = GoodWeProcessor()
         ret_val = processor.run_process()
         sys.exit(retval)
- 
+
     daemon = MyDaemon('/var/run/goodwecomm.pid', '/dev/null', '/dev/null', '/dev/null')
+ 
     if 'start' == sys.argv[1]:
         daemon.start()
     elif 'stop' == sys.argv[1]:

--- a/GoodWe.py
+++ b/GoodWe.py
@@ -1,4 +1,6 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python3 -tt
+from __future__ import absolute_import
+from __future__ import print_function
 from daemonpy.daemon import Daemon
 
 import configparser
@@ -102,12 +104,12 @@ class MyDaemon(Daemon):
     
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print ("usage: %s start|stop|restart" % sys.argv[0])
+        print(("usage: %s start|stop|restart" % sys.argv[0]))
         sys.exit(2)
 
     if 'foreground' == sys.argv[1]:
         processor = GoodWeProcessor()
-        ret_val = processor.run_process(foreground=True)
+        retval = processor.run_process(foreground=True)
         sys.exit(retval)
 
     daemon = MyDaemon('/var/run/goodwecomm.pid', '/dev/null', '/dev/null', '/dev/null')

--- a/GoodWe.py
+++ b/GoodWe.py
@@ -102,7 +102,7 @@ class MyDaemon(Daemon):
     
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print ("usage: %s start|stop|restart" % sys.argv[0])
+        print ("usage: %s start|stop|restart|foreground" % sys.argv[0])
         sys.exit(2)
 
     if 'foreground' == sys.argv[1]:

--- a/GoodWe.py
+++ b/GoodWe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -tt
+#!/usr/bin/python -tt
 from __future__ import absolute_import
 from __future__ import print_function
 from daemonpy.daemon import Daemon
@@ -9,7 +9,6 @@ from logging.handlers import TimedRotatingFileHandler
 import sys
 import paho.mqtt.client as mqtt
 import time
-import json
 import os
 
 import GoodWeCommunicator as goodwe

--- a/GoodWeCommunicator.py
+++ b/GoodWeCommunicator.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from enum import Enum
 
 import time
@@ -7,6 +8,8 @@ import hidrawpure as hidraw
 import os, fcntl
 import logging
 import json
+from six.moves import map
+from six.moves import range
 
 millis = lambda: int(round(time.time() * 1000))
 

--- a/GoodWeCommunicator.py
+++ b/GoodWeCommunicator.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from enum import Enum
+from enum import IntEnum
 
 import time
 from pyudev import Devices, Context, Monitor, MonitorObserver
@@ -7,7 +7,8 @@ import datetime
 import hidrawpure as hidraw
 import os, fcntl
 import logging
-import json
+# simplejson supports byte strings
+import simplejson as json
 from six.moves import map
 from six.moves import range
 
@@ -28,7 +29,6 @@ class IDInfo(object):
         
     def toJSON(self):
         return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
-        
 
 class SettingInfo(object):
 
@@ -138,9 +138,8 @@ class Inverter(object):
         
     def toJSON(self):
         return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
-        
 
-class State(Enum):
+class State(IntEnum):
     OFFLINE = 1
     CONNECTED = 2
     DISCOVER = 3
@@ -154,7 +153,7 @@ class State(Enum):
     RUNNING = 11
 
 
-class InverterType(Enum):
+class InverterType(IntEnum):
     SINGLEPHASE = 1
     THREEPHASE = 3
     
@@ -329,9 +328,11 @@ class GoodWeCommunicator(object):
     def checkIncomingData(self):
         try:
             datstr = self.devfp.read(8)
+            if datstr == None:
+                raise IOError
 
-            for data in datstr:
-                incomingData = ord(data)
+            for data in bytearray(datstr):
+                incomingData = data
                 # continuously check for GoodWe HEADER packets.
                 # Some types of Inverters send out garbage all the time. The header packet is the only true marker for a meaningfull command following.
                 if self.lastReceivedByte == 0xAA and incomingData == 0x55:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Almost all configuration parameters have sensible defaults and are commented out
 setting remove the # in front of the parameter name.
 Only when username and the optional password are set, they will be used. Setting the username will trigger authentication for the MQTT server. 
 Password can optionally be set.
+Please note that the logfile is nt used when used in foreground mode.
 
 ## Usage
 
@@ -72,6 +73,11 @@ To start the daemon application:
 
 ```bash
 $ sudo ./GoodWe.py start
+```
+The program can also be started in the foreground with all logging to stderr (the logfile is not used). Strt the program as follows:
+
+```bash
+$ sudo ./Goodwe.py foreground
 ```
 
 ## Inverter information
@@ -100,3 +106,25 @@ goodwe "GoodWe.py" "cd /opt/goodweusblogger; ./GoodWe.py restart"
 ```
 
 I have everything running from _/opt/goodweusblogger_. If you have your application installed somewhere else you need to update the above statement.
+
+## Systemd
+
+Running under systemd is an option for using restartd. Systemd will collect all logging information in it's journal. The following goodwe.service file runs under the user "goodwe".
+Create the user as follows:
+
+```bash
+
+useradd --system goodwe
+
+```
+
+and modify the _/etc/udev/rules.d/98-my-usb-device.rules_ as follows:
+
+```bash
+
+SUBSYSTEM=="input", GROUP="input", MODE="0666"
+KERNEL=="hidraw*", ATTRS{busnum}=="1", ATTRS{idVendor}=="0084", ATTRS{idProduct}=="0041", MODE="0660", GROUP="goodwe"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0084", ATTRS{idProduct}=="0041", MODE="0660", GROUP="plugdev", SYMLINK+="goodwe"
+
+```
+

--- a/README.md
+++ b/README.md
@@ -42,18 +42,25 @@ Create file _/etc/goodwe.conf_:
 
 ```
 [inverter]
-loglevel = INFO
-pollinterval = 2500
-vendorId = 0084
-modelId = 0041
-logfile = /var/log/goodwe.log
+#loglevel = DEBUG
+#pollinterval = 2500
+#vendorId = 0084
+#modelId = 0041
+#logfile = /var/log/goodwe.log
 
 [mqtt]
-server = <MQTT Server IP>
-port = 1883
-topic = goodwe
-clientid = <unique MQTT client id>
+#server = localhost
+#port = 1883
+#topic = goodwe
+#clientid = goodwe-usb
+#username = 
+#password = mypassword
+
 ```
+Almost all configuration parameters have sensible defaults and are commented out. The values shown are the defaults. If you ned to change a 
+setting remove the # in front of the parameter name.
+Only when username and the optional password are set, they will be used. Setting the username will trigger authentication for the MQTT server. 
+Password can optionally be set.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Create file _/etc/goodwe.conf_:
 #password = mypassword
 
 ```
-Almost all configuration parameters have sensible defaults and are commented out. The values shown are the defaults. If you ned to change a 
+Almost all configuration parameters have sensible defaults and are commented out. The values shown are the defaults. If you need to change a 
 setting remove the # in front of the parameter name.
 Only when username and the optional password are set, they will be used. Setting the username will trigger authentication for the MQTT server. 
 Password can optionally be set.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Python 2.7 is already installed (at least on my Raspberry Zero W)
 sudo apt-get update
 sudo apt-get install -y python-pip
 ```
-for python3 install python3-pip instead of python-pip.
+for python3 install _python3-pip_ instead of _python-pip_.
 
 ## Required python modules
 
@@ -31,15 +31,15 @@ for python3 install python3-pip instead of python-pip.
 ```bash
 sudo python -m pip install configparser paho-mqtt pyudev ioctl_opt simplejson
 ```
-Use pip3 instead of pip when you want to use python3.
+Use _pip3_ instead of _pip_ when you want to use python3.
 
 If you installed enum on Raspbian in the past, remove it and re-install the python-enum34 package.
 ```bash
 pip uninstall enum
 apt-get install --reinstall python-enum34
+```
 
 The standard package python-enum34 is more feature rich than the enum module.
-```
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Almost all configuration parameters have sensible defaults and are commented out
 setting remove the # in front of the parameter name.
 Only when username and the optional password are set, they will be used. Setting the username will trigger authentication for the MQTT server. 
 Password can optionally be set.
-Please note that the logfile is nt used when used in foreground mode.
+Please note that the logfile is not used when used in foreground mode.
 
 ## Usage
 
@@ -74,7 +74,7 @@ To start the daemon application:
 ```bash
 $ sudo ./GoodWe.py start
 ```
-The program can also be started in the foreground with all logging to stderr (the logfile is not used). Strt the program as follows:
+The program can also be started in the foreground with all logging to stderr (the logfile is not used). Start the program as follows:
 
 ```bash
 $ sudo ./Goodwe.py foreground
@@ -109,7 +109,9 @@ I have everything running from _/opt/goodweusblogger_. If you have your applicat
 
 ## Systemd
 
-Running under systemd is an option for using restartd. Systemd will collect all logging information in it's journal. The following goodwe.service file runs under the user "goodwe".
+Running under systemd is an option for using restartd. Systemd will collect all logging information in it's journal. 
+The service unit allows one to run as a system user.
+
 Create the user as follows:
 
 ```bash
@@ -127,4 +129,23 @@ KERNEL=="hidraw*", ATTRS{busnum}=="1", ATTRS{idVendor}=="0084", ATTRS{idProduct}
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0084", ATTRS{idProduct}=="0041", MODE="0660", GROUP="plugdev", SYMLINK+="goodwe"
 
 ```
+The following goodwe.service file shall be placed in _/etc/systemd/system/goodwe.service.
 
+```bash
+[Unit]
+Description=Goodwe USB Logger
+After=basic.target
+
+[Service]
+Type=simple
+User=goodwe
+Group=goodwe
+ExecStart=/opt/goodweusblogger/GoodWe.py foreground
+Restart=always
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+The program can now as usual be started by _systemctl start goodwe.service_

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ KERNEL=="hidraw*", ATTRS{busnum}=="1", ATTRS{idVendor}=="0084", ATTRS{idProduct}
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0084", ATTRS{idProduct}=="0041", MODE="0660", GROUP="plugdev", SYMLINK+="goodwe"
 
 ```
-The following goodwe.service file shall be placed in _/etc/systemd/system/goodwe.service.
+The following goodwe.service file shall be placed in _/etc/systemd/system/goodwe.service_.
 
 ```bash
 [Unit]
@@ -149,3 +149,4 @@ StandardError=journal
 WantedBy=multi-user.target
 ```
 The program can now as usual be started by _systemctl start goodwe.service_
+Systemd will run the program as the user goodwe and take care of restarting it when necessary. All logging information will be shown in the systemd logs.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ based on: https://github.com/jantenhove/GoodWeLogger
 
 ## Required Python version
 
-I'm currently using **Python 2.7.13** on a Raspberry Pi for this project. It has been verified that it is **_NOT_** working with Python 3.
+I'm currently using **Python 2.7.13** on a Raspberry Pi for this project but the GoodWeUSBLogger has now been ported to python3. This version 
+supports both python2 and python3.
 Python 2.7 is already installed (at least on my Raspberry Zero W)
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y python-pip
 ```
+for python3 install python3-pip instead of python-pip.
 
 ## Required python modules
 
@@ -23,10 +25,20 @@ sudo apt-get install -y python-pip
 * paho-mqtt
 * pyudev
 * ioctl_opt
-* enum
+* enum34 (standard installed on Raspbian, but see below)
+* simplejson
 
 ```bash
-sudo python -m pip install configparser paho-mqtt pyudev ioctl_opt enum
+sudo python -m pip install configparser paho-mqtt pyudev ioctl_opt simplejson
+```
+Use pip3 instead of pip when you want to use python3.
+
+If you installed enum on Raspbian in the past, remove it and re-install the python-enum34 package.
+```bash
+pip uninstall enum
+apt-get install --reinstall python-enum34
+
+The standard package python-enum34 is more feature rich than the enum module.
 ```
 
 ## Config
@@ -150,3 +162,6 @@ WantedBy=multi-user.target
 ```
 The program can now as usual be started by _systemctl start goodwe.service_
 Systemd will run the program as the user goodwe and take care of restarting it when necessary. All logging information will be shown in the systemd logs.
+
+## python3
+Most of the information on python3 can be found above. Right now python2 is the default. If you want to use python3, replace the _#!/usr/bin/python_ at the top of _GoodWe.py_ with _#!/usr/bin/python3_, leave the rest of the line unchanged.

--- a/hidrawpure.py
+++ b/hidrawpure.py
@@ -7,6 +7,7 @@ from https://github.com/vpelletier/python-hidraw
 from __future__ import absolute_import
 from __future__ import print_function
 import ctypes
+import struct
 import collections
 import fcntl
 import ioctl_opt
@@ -23,7 +24,7 @@ BUS_VIRTUAL = 0x06
 # hid.h
 _HID_MAX_DESCRIPTOR_SIZE = 4096
 
-if sys.version < '3':
+if sys.version[0] < '3':
     def b(x):
         return x
 else:
@@ -90,7 +91,7 @@ class HIDRaw(object):
         self._ioctl(_HIDIOCGRDESCSIZE, size, True)
         descriptor.size = size
         self._ioctl(_HIDIOCGRDESC, descriptor, True)
-        return ''.join(chr(x) for x in descriptor.value[:size.value])
+        return b''.join(chr(x) for x in descriptor.value[:size.value])
 
     # TODO: decode descriptor into a python object
     #def getReportDescriptor(self):
@@ -130,16 +131,17 @@ class HIDRaw(object):
         Send an output report.
         """
         length = len(report) + 1
-        buf = ctypes.create_string_buffer(b(chr(report_num) + report), length)
+        buf = ctypes.create_string_buffer(struct.pack("B", report_num) + report, length)
         self._device.write(buf)
 
+# sendFeatureReport seems to be unused, remove it?
 
     def sendFeatureReport(self, report, report_num=0):
         """
         Send a feature report.
         """
         length = len(report) + 1
-        buf = ctypes.create_string_buffer(b(chr(report_num) + report), length)
+        buf = ctypes.create_string_buffer(b(struct.pack("B", report_num) + report), length)
         self._ioctl(_HIDIOCSFEATURE(length), buf, True)
         print(_HIDIOCSFEATURE(length))
 

--- a/hidrawpure.py
+++ b/hidrawpure.py
@@ -4,6 +4,8 @@ from https://github.com/vpelletier/python-hidraw
  copied and renamed due to the existence of another 'hidraw' package on pypi which seems to conflict in some way.
 
 """
+from __future__ import absolute_import
+from __future__ import print_function
 import ctypes
 import collections
 import fcntl
@@ -139,7 +141,7 @@ class HIDRaw(object):
         length = len(report) + 1
         buf = ctypes.create_string_buffer(b(chr(report_num) + report), length)
         self._ioctl(_HIDIOCSFEATURE(length), buf, True)
-        print _HIDIOCSFEATURE(length)
+        print(_HIDIOCSFEATURE(length))
 
     def getFeatureReport(self, report_num=0, length=63):
         """


### PR DESCRIPTION
Hi
I spent some time porting the USBLogger to python 3. Some parts were tricky as python3 uses unicode strings, so I had to port some stuff for bytes/byte arrays. I replaced json by simplejson as that supports serialization of byte strings, whereas the standard json does not. I switched from enum to enum34 to be able to convert Enum to IntEnum as Enum can not be serialized.

I don't recall where I got daemonpy (was a bit tricky to find out how to get it). The diff is however really simple:
diff --git a/daemon.py b/daemon.py
index d5fcd23..ed5fd0b 100644
--- a/daemon.py
+++ b/daemon.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import
+from __future__ import print_function
 import sys, os, time, atexit
 from signal import SIGTERM 

So just some imports from __future__

One more question: Serial number is output as an array of values. Should that not be a string/ byte string?

 