### PR TITLE
Python3 rebased

### DIFF
--- a/GoodWe.py
+++ b/GoodWe.py
@@ -1,4 +1,6 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python3 -tt
+from __future__ import absolute_import
+from __future__ import print_function
 from daemonpy.daemon import Daemon
 
 import configparser
@@ -107,7 +109,7 @@ if __name__ == "__main__":
 
     if 'foreground' == sys.argv[1]:
         processor = GoodWeProcessor()
-        ret_val = processor.run_process(foreground=True)
+        retval = processor.run_process(foreground=True)
         sys.exit(retval)
 
     daemon = MyDaemon('/var/run/goodwecomm.pid', '/dev/null', '/dev/null', '/dev/null')

--- a/GoodWe.py
+++ b/GoodWe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -tt
+#!/usr/bin/python -tt
 from __future__ import absolute_import
 from __future__ import print_function
 from daemonpy.daemon import Daemon
@@ -9,7 +9,6 @@ from logging.handlers import TimedRotatingFileHandler
 import sys
 import paho.mqtt.client as mqtt
 import time
-import json
 import os
 
 import GoodWeCommunicator as goodwe

--- a/GoodWeCommunicator.py
+++ b/GoodWeCommunicator.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from enum import Enum
 
 import time
@@ -7,6 +8,8 @@ import hidrawpure as hidraw
 import os, fcntl
 import logging
 import json
+from six.moves import map
+from six.moves import range
 
 millis = lambda: int(round(time.time() * 1000))
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Python 2.7 is already installed (at least on my Raspberry Zero W)
 sudo apt-get update
 sudo apt-get install -y python-pip
 ```
-for python3 install python3-pip instead of python-pip.
+for python3 install _python3-pip_ instead of _python-pip_.
 
 ## Required python modules
 
@@ -31,15 +31,15 @@ for python3 install python3-pip instead of python-pip.
 ```bash
 sudo python -m pip install configparser paho-mqtt pyudev ioctl_opt simplejson
 ```
-Use pip3 instead of pip when you want to use python3.
+Use _pip3_ instead of _pip_ when you want to use python3.
 
 If you installed enum on Raspbian in the past, remove it and re-install the python-enum34 package.
 ```bash
 pip uninstall enum
 apt-get install --reinstall python-enum34
+```
 
 The standard package python-enum34 is more feature rich than the enum module.
-```
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ based on: https://github.com/jantenhove/GoodWeLogger
 
 ## Required Python version
 
-I'm currently using **Python 2.7.13** on a Raspberry Pi for this project. It has been verified that it is **_NOT_** working with Python 3.
+I'm currently using **Python 2.7.13** on a Raspberry Pi for this project but the GoodWeUSBLogger has now been ported to python3. This version 
+supports both python2 and python3.
 Python 2.7 is already installed (at least on my Raspberry Zero W)
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y python-pip
 ```
+for python3 install python3-pip instead of python-pip.
 
 ## Required python modules
 
@@ -23,10 +25,20 @@ sudo apt-get install -y python-pip
 * paho-mqtt
 * pyudev
 * ioctl_opt
-* enum
+* enum34 (standard installed on Raspbian, but see below)
+* simplejson
 
 ```bash
-sudo python -m pip install configparser paho-mqtt pyudev ioctl_opt enum
+sudo python -m pip install configparser paho-mqtt pyudev ioctl_opt simplejson
+```
+Use pip3 instead of pip when you want to use python3.
+
+If you installed enum on Raspbian in the past, remove it and re-install the python-enum34 package.
+```bash
+pip uninstall enum
+apt-get install --reinstall python-enum34
+
+The standard package python-enum34 is more feature rich than the enum module.
 ```
 
 ## Config
@@ -150,3 +162,6 @@ WantedBy=multi-user.target
 ```
 The program can now as usual be started by _systemctl start goodwe.service_
 Systemd will run the program as the user goodwe and take care of restarting it when necessary. All logging information will be shown in the systemd logs.
+
+## python3
+Most of the information on python3 can be found above. Right now python2 is the default. If you want to use python3, replace the _#!/usr/bin/python_ at the top of _GoodWe.py_ with _#!/usr/bin/python3_, leave the rest of the line unchanged.

--- a/hidrawpure.py
+++ b/hidrawpure.py
@@ -7,6 +7,7 @@ from https://github.com/vpelletier/python-hidraw
 from __future__ import absolute_import
 from __future__ import print_function
 import ctypes
+import struct
 import collections
 import fcntl
 import ioctl_opt
@@ -23,7 +24,7 @@ BUS_VIRTUAL = 0x06
 # hid.h
 _HID_MAX_DESCRIPTOR_SIZE = 4096
 
-if sys.version < '3':
+if sys.version[0] < '3':
     def b(x):
         return x
 else:
@@ -90,7 +91,7 @@ class HIDRaw(object):
         self._ioctl(_HIDIOCGRDESCSIZE, size, True)
         descriptor.size = size
         self._ioctl(_HIDIOCGRDESC, descriptor, True)
-        return ''.join(chr(x) for x in descriptor.value[:size.value])
+        return b''.join(chr(x) for x in descriptor.value[:size.value])
 
     # TODO: decode descriptor into a python object
     #def getReportDescriptor(self):
@@ -130,16 +131,17 @@ class HIDRaw(object):
         Send an output report.
         """
         length = len(report) + 1
-        buf = ctypes.create_string_buffer(b(chr(report_num) + report), length)
+        buf = ctypes.create_string_buffer(struct.pack("B", report_num) + report, length)
         self._device.write(buf)
 
+# sendFeatureReport seems to be unused, remove it?
 
     def sendFeatureReport(self, report, report_num=0):
         """
         Send a feature report.
         """
         length = len(report) + 1
-        buf = ctypes.create_string_buffer(b(chr(report_num) + report), length)
+        buf = ctypes.create_string_buffer(b(struct.pack("B", report_num) + report), length)
         self._ioctl(_HIDIOCSFEATURE(length), buf, True)
         print(_HIDIOCSFEATURE(length))
 

--- a/hidrawpure.py
+++ b/hidrawpure.py
@@ -4,6 +4,8 @@ from https://github.com/vpelletier/python-hidraw
  copied and renamed due to the existence of another 'hidraw' package on pypi which seems to conflict in some way.
 
 """
+from __future__ import absolute_import
+from __future__ import print_function
 import ctypes
 import collections
 import fcntl
@@ -139,7 +141,7 @@ class HIDRaw(object):
         length = len(report) + 1
         buf = ctypes.create_string_buffer(b(chr(report_num) + report), length)
         self._ioctl(_HIDIOCSFEATURE(length), buf, True)
-        print _HIDIOCSFEATURE(length)
+        print(_HIDIOCSFEATURE(length))
 
     def getFeatureReport(self, report_num=0, length=63):
         """


### PR DESCRIPTION
This is a new pull request, as I completely messed up my python3 branch. This new branch is based on your master with the python3 patches cherry-picked from the old python 3 branch. 

As with the previous patch set, I was not sure how to handle patches for daemonpy.
I don't recall where I got daemonpy (was a bit tricky to find out how to get it). The diff is however really simple:
diff --git a/daemon.py b/daemon.py
index d5fcd23..ed5fd0b 100644
--- a/daemon.py
+++ b/daemon.py
@@ -1,5 +1,7 @@
#!/usr/bin/python

+from future import absolute_import
+from future import print_function
import sys, os, time, atexit
from signal import SIGTERM 

As for the issue in serialNumber: when I dump the generated json with mosquitto_sub, I get 
.
.
"serial": "13000DSN162W0060",
    "serialNumber": [
        49,
        51,
        48,
        48,
        48,
        68,
        83,
        78,
        49,
        54,
        50,
        87,
        48,
        48,
        54,
        48
    ],

What is the purpose of reporting the serialnumber as a list rather than a string?
Thanks for your merging of my patches so far

kind regards, Louis
