### PR TITLE
Add entry for python-daemon submodule in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,31 @@ apt-get install --reinstall python-enum34
 The standard package python-enum34 is more feature rich than the enum module.
 ```
 
+## Check out repository and submodule
+
+Because of a dependency to the `python-daemon` repository, the easiest method for getting both repositories on your device is through Git.
+
+Install Git if you haven't already:
+
+```bash
+sudo apt-install -y git
+```
+
+Next, we need to check out this repository's code:
+
+```bash
+cd /opt
+sudo mkdir goodweusblogger
+sudo git clone https://github.com/sircuri/GoodWeUSBLogger.git goodweusblogger
+```
+
+Navigate to the _/opt/goodweusblogger/daemonpy_ folder, and execute the following command: 
+```bash
+git submodule update --init
+```
+
+This will check out the `python-daemon` submodule.
+
 ## Config
 
 Create file _/etc/udev/rules.d/98-my-usb-device.rules_ with:


### PR DESCRIPTION
The dependency on the python-daemon submodule was not explained in the README. Added it, along with some basic explanation about git checkouts for those not common with Git.

Resolves this issue: https://github.com/sircuri/GoodWeUSBLogger/issues/12